### PR TITLE
feat: add prompt settings features and dark theme

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -10,6 +10,7 @@ import { video } from "./routes/video.js";
 import { admin } from "./routes/admin.js";
 import auth from "./routes/auth.js";
 import prompts from "./routes/prompts.js";
+import userSettings from "./routes/user-settings.js";
 import { databaseService } from "./services/database-service.js";
 
 const app = new Hono();
@@ -48,6 +49,7 @@ app.route("/video", video);
 app.route("/admin", admin);
 app.route("/auth", auth);
 app.route("/prompts", prompts);
+app.route("/user-settings", userSettings);
 
 const port = parseInt(process.env.PORT || "8787");
 

--- a/apps/api/src/routes/prompts.ts
+++ b/apps/api/src/routes/prompts.ts
@@ -160,4 +160,40 @@ app.delete('/', async (c) => {
   }
 });
 
+// 統合プロンプト（グローバル + プラットフォーム固有）を取得
+app.get('/combined', async (c) => {
+  try {
+    const userId = c.get('userId') as string;
+    const combinedPrompts = await promptService.getCombinedPrompts(userId);
+
+    return c.json({ prompts: combinedPrompts });
+  } catch (error) {
+    console.error('Error fetching combined prompts:', error);
+    return c.json({ error: 'Failed to fetch combined prompts' }, 500);
+  }
+});
+
+// 特定プラットフォームの統合プロンプトを取得
+app.get('/combined/:platform', async (c) => {
+  try {
+    const userId = c.get('userId') as string;
+    const platform = c.req.param('platform') as Platform;
+
+    const validPlatforms: Platform[] = ['twitter', 'instagram', 'tiktok', 'threads', 'youtube', 'blog'];
+    if (!validPlatforms.includes(platform)) {
+      return c.json({ error: 'Invalid platform' }, 400);
+    }
+
+    const combinedPrompt = await promptService.getCombinedPrompt(userId, platform);
+
+    return c.json({
+      platform,
+      combinedPrompt
+    });
+  } catch (error) {
+    console.error('Error fetching combined prompt:', error);
+    return c.json({ error: 'Failed to fetch combined prompt' }, 500);
+  }
+});
+
 export default app;

--- a/apps/api/src/routes/user-settings.ts
+++ b/apps/api/src/routes/user-settings.ts
@@ -1,0 +1,119 @@
+import { Hono } from 'hono';
+import { authMiddleware } from '../middlewares/auth.js';
+import { UserSettingsService } from '../services/user-settings-service.js';
+
+type Variables = {
+  userId: string;
+  email: string;
+  name: string;
+};
+
+const app = new Hono<{ Variables: Variables }>();
+const userSettingsService = new UserSettingsService();
+
+// 全てのエンドポイントに認証を適用
+app.use('*', authMiddleware);
+
+// グローバルキャラクタープロンプトを取得
+app.get('/global-character-prompt', async (c) => {
+  try {
+    const userId = c.get('userId') as string;
+    const prompt = await userSettingsService.getGlobalCharacterPrompt(userId);
+
+    return c.json({
+      globalCharacterPrompt: prompt || userSettingsService.getDefaultGlobalCharacterPrompt()
+    });
+  } catch (error) {
+    console.error('Error fetching global character prompt:', error);
+    return c.json({ error: 'Failed to fetch global character prompt' }, 500);
+  }
+});
+
+// グローバルキャラクタープロンプトを保存
+app.put('/global-character-prompt', async (c) => {
+  try {
+    const userId = c.get('userId') as string;
+    const { prompt } = await c.req.json<{ prompt: string }>();
+
+    if (!prompt || typeof prompt !== 'string') {
+      return c.json({ error: 'Invalid prompt' }, 400);
+    }
+
+    if (prompt.length > 5000) {
+      return c.json({ error: 'Prompt is too long (max 5000 characters)' }, 400);
+    }
+
+    const savedSettings = await userSettingsService.saveGlobalCharacterPrompt(userId, prompt);
+    return c.json({
+      message: 'Global character prompt saved successfully',
+      globalCharacterPrompt: savedSettings.global_character_prompt
+    });
+  } catch (error) {
+    console.error('Error saving global character prompt:', error);
+    return c.json({ error: 'Failed to save global character prompt' }, 500);
+  }
+});
+
+// グローバルキャラクタープロンプトを削除（デフォルトに戻す）
+app.delete('/global-character-prompt', async (c) => {
+  try {
+    const userId = c.get('userId') as string;
+    await userSettingsService.deleteGlobalCharacterPrompt(userId);
+
+    return c.json({
+      message: 'Global character prompt reset to default',
+      globalCharacterPrompt: userSettingsService.getDefaultGlobalCharacterPrompt()
+    });
+  } catch (error) {
+    console.error('Error resetting global character prompt:', error);
+    return c.json({ error: 'Failed to reset global character prompt' }, 500);
+  }
+});
+
+// ユーザー設定全体を取得
+app.get('/', async (c) => {
+  try {
+    const userId = c.get('userId') as string;
+    let settings = await userSettingsService.getUserSettings(userId);
+
+    // 初回アクセス時は設定を初期化
+    if (!settings) {
+      settings = await userSettingsService.initializeUserSettings(userId);
+    }
+
+    return c.json({
+      settings: {
+        userId: settings.user_id,
+        globalCharacterPrompt: settings.global_character_prompt || userSettingsService.getDefaultGlobalCharacterPrompt(),
+        createdAt: settings.created_at,
+        updatedAt: settings.updated_at
+      }
+    });
+  } catch (error) {
+    console.error('Error fetching user settings:', error);
+    return c.json({ error: 'Failed to fetch user settings' }, 500);
+  }
+});
+
+// ユーザー設定を初期化（新規ユーザー登録時などに使用）
+app.post('/initialize', async (c) => {
+  try {
+    const userId = c.get('userId') as string;
+    const settings = await userSettingsService.initializeUserSettings(userId);
+
+    return c.json({
+      message: 'User settings initialized successfully',
+      settings: {
+        userId: settings.user_id,
+        globalCharacterPrompt: settings.global_character_prompt,
+        createdAt: settings.created_at,
+        updatedAt: settings.updated_at
+      }
+    });
+  } catch (error) {
+    console.error('Error initializing user settings:', error);
+    return c.json({ error: 'Failed to initialize user settings' }, 500);
+  }
+});
+
+export default app;

--- a/apps/api/src/services/user-settings-service.ts
+++ b/apps/api/src/services/user-settings-service.ts
@@ -1,0 +1,101 @@
+import { Pool } from 'pg';
+import { pool as defaultPool } from '../db/pool.js';
+
+export interface UserSettings {
+  user_id: string;
+  global_character_prompt?: string;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+export class UserSettingsService {
+  private pool: Pool;
+
+  constructor(pool?: Pool) {
+    this.pool = pool || defaultPool;
+  }
+
+  /**
+   * ユーザーのグローバルキャラクタープロンプトを取得
+   */
+  async getGlobalCharacterPrompt(userId: string): Promise<string | null> {
+    const result = await this.pool.query(
+      'SELECT global_character_prompt FROM user_settings WHERE user_id = $1 LIMIT 1',
+      [userId]
+    );
+    return result.rows[0]?.global_character_prompt || null;
+  }
+
+  /**
+   * ユーザーのグローバルキャラクタープロンプトを保存
+   */
+  async saveGlobalCharacterPrompt(userId: string, prompt: string): Promise<UserSettings> {
+    const result = await this.pool.query(
+      `INSERT INTO user_settings (user_id, global_character_prompt, created_at, updated_at)
+       VALUES ($1, $2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+       ON CONFLICT (user_id)
+       DO UPDATE SET
+         global_character_prompt = EXCLUDED.global_character_prompt,
+         updated_at = CURRENT_TIMESTAMP
+       RETURNING *`,
+      [userId, prompt]
+    );
+    return result.rows[0];
+  }
+
+  /**
+   * ユーザーのグローバルキャラクタープロンプトを削除
+   */
+  async deleteGlobalCharacterPrompt(userId: string): Promise<boolean> {
+    const result = await this.pool.query(
+      'UPDATE user_settings SET global_character_prompt = NULL, updated_at = CURRENT_TIMESTAMP WHERE user_id = $1',
+      [userId]
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  /**
+   * ユーザー設定を初期化（ユーザー登録時に使用）
+   */
+  async initializeUserSettings(userId: string): Promise<UserSettings> {
+    const defaultPrompt = 'あなたは親しみやすく、創造性豊かなコンテンツクリエイターです。読者・視聴者に価値のある情報を分かりやすく、魅力的に伝えることを心がけています。';
+
+    const result = await this.pool.query(
+      `INSERT INTO user_settings (user_id, global_character_prompt, created_at, updated_at)
+       VALUES ($1, $2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+       ON CONFLICT (user_id)
+       DO NOTHING
+       RETURNING *`,
+      [userId, defaultPrompt]
+    );
+
+    // 既存の場合は現在の設定を返す
+    if (result.rows.length === 0) {
+      const existing = await this.pool.query(
+        'SELECT * FROM user_settings WHERE user_id = $1',
+        [userId]
+      );
+      return existing.rows[0];
+    }
+
+    return result.rows[0];
+  }
+
+  /**
+   * ユーザー設定全体を取得
+   */
+  async getUserSettings(userId: string): Promise<UserSettings | null> {
+    const result = await this.pool.query(
+      'SELECT * FROM user_settings WHERE user_id = $1',
+      [userId]
+    );
+    return result.rows[0] || null;
+  }
+
+  /**
+   * デフォルトのグローバルキャラクタープロンプトを取得
+   */
+  getDefaultGlobalCharacterPrompt(): string {
+    return 'あなたは親しみやすく、創造性豊かなコンテンツクリエイターです。読者・視聴者に価値のある情報を分かりやすく、魅力的に伝えることを心がけています。';
+  }
+}

--- a/apps/web/src/app/HomeContent.tsx
+++ b/apps/web/src/app/HomeContent.tsx
@@ -18,6 +18,7 @@ export default function HomeContent({ userId, isAuthenticated }: HomeContentProp
   const router = useRouter();
   const searchParams = useSearchParams();
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
+  const [tempPrompts, setTempPrompts] = useState<Record<string, string>>({});
   const { isSidebarOpen, closeSidebar } = useSidebar();
 
   useEffect(() => {
@@ -61,9 +62,9 @@ export default function HomeContent({ userId, isAuthenticated }: HomeContentProp
   };
 
   return (
-    <div className="flex h-[calc(100vh-64px)] bg-gray-50 overflow-hidden">
+    <div className="flex min-h-[calc(100vh-64px)] bg-gray-900">
       {/* Sidebar */}
-      <Sidebar 
+      <Sidebar
         selectedThreadId={selectedThreadId}
         onThreadSelect={handleThreadSelect}
         onNewChat={handleNewChat}
@@ -71,24 +72,24 @@ export default function HomeContent({ userId, isAuthenticated }: HomeContentProp
         onClose={closeSidebar}
         isAuthenticated={isAuthenticated}
       />
-      
+
       {/* Main Content */}
       <div className="flex-1 flex flex-col md:ml-0">
         {selectedThreadId ? (
           <ThreadView threadId={selectedThreadId} userId={userId} />
         ) : (
-          <div className="flex-1 overflow-y-auto">
+          <div className="flex-1 py-4 md:py-8">
             <div className="max-w-4xl mx-auto px-4 md:px-6 py-4 md:py-8">
               <header className="mb-6 md:mb-8 text-center">
-                <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-2">
+                <h1 className="text-2xl md:text-3xl font-bold text-white mb-2">
                   One to Multi Agent
                 </h1>
-                <p className="text-gray-600 text-sm md:text-base">
+                <p className="text-gray-300 text-sm md:text-base">
                   1つのソースから複数プラットフォーム向けのコンテンツを自動生成
                 </p>
               </header>
 
-              <SourceForm 
+              <SourceForm
                 sourceType={sourceType}
                 setSourceType={setSourceType}
                 content={content}
@@ -98,24 +99,28 @@ export default function HomeContent({ userId, isAuthenticated }: HomeContentProp
                 setTargets={setTargets}
                 isProcessing={isProcessing}
                 handleSubmit={handleSubmit}
+                userId={userId}
+                isAuthenticated={isAuthenticated}
+                tempPrompts={tempPrompts}
+                onTempPromptsChange={setTempPrompts}
               />
 
               {isProcessing && !results && (
                 <div className="mt-4 md:mt-6 text-center">
-                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div>
-                  <p className="mt-2 text-blue-800 text-sm md:text-base">コンテンツを処理中です...</p>
+                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-400 mx-auto"></div>
+                  <p className="mt-2 text-blue-300 text-sm md:text-base">コンテンツを処理中です...</p>
                 </div>
               )}
 
               {error && (
-                <div className="mt-4 md:mt-6 bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative text-sm md:text-base">
+                <div className="mt-4 md:mt-6 bg-red-900 border border-red-700 text-red-300 px-4 py-3 rounded relative text-sm md:text-base">
                   <strong>エラー:</strong> {error}
                 </div>
               )}
 
-              <ResultsDisplay 
-                results={results} 
-                editableContent={editableContent} 
+              <ResultsDisplay
+                results={results}
+                editableContent={editableContent}
                 updateEditableContent={updateEditableContent}
                 handlePublish={handlePublish}
               />

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -32,7 +32,7 @@ export default async function RootLayout({
   return (
     <html lang="ja">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased h-screen overflow-hidden`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen`}
       >
         <Script src="/runtime-config.js" strategy="beforeInteractive" />
         <SidebarProvider>

--- a/apps/web/src/app/settings/character/CharacterPromptForm.tsx
+++ b/apps/web/src/app/settings/character/CharacterPromptForm.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface CharacterPromptFormProps {
+  initialPrompt: string;
+  token: string;
+}
+
+export function CharacterPromptForm({ initialPrompt, token }: CharacterPromptFormProps) {
+  const router = useRouter();
+  const [prompt, setPrompt] = useState(initialPrompt);
+  const [editingPrompt, setEditingPrompt] = useState(initialPrompt);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8787';
+
+  const handleSave = async () => {
+    setSaving(true);
+    setMessage(null);
+
+    try {
+      const response = await fetch(`${apiUrl}/user-settings/global-character-prompt`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ prompt: editingPrompt })
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to save global character prompt');
+      }
+
+      const data = await response.json();
+      setPrompt(data.globalCharacterPrompt);
+      setIsEditing(false);
+      setMessage({ type: 'success', text: 'キャラクタープロンプトを保存しました' });
+      router.refresh();
+    } catch (error) {
+      console.error('Failed to save global character prompt:', error);
+      setMessage({ type: 'error', text: 'キャラクタープロンプトの保存に失敗しました' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = async () => {
+    if (!confirm('キャラクタープロンプトをデフォルトに戻しますか？')) {
+      return;
+    }
+
+    setSaving(true);
+    setMessage(null);
+
+    try {
+      const response = await fetch(`${apiUrl}/user-settings/global-character-prompt`, {
+        method: 'DELETE',
+        headers: {
+          'Authorization': `Bearer ${token}`
+        }
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to reset global character prompt');
+      }
+
+      const data = await response.json();
+      setPrompt(data.globalCharacterPrompt);
+      setEditingPrompt(data.globalCharacterPrompt);
+      setIsEditing(false);
+      setMessage({ type: 'success', text: 'キャラクタープロンプトをデフォルトに戻しました' });
+      router.refresh();
+    } catch (error) {
+      console.error('Failed to reset global character prompt:', error);
+      setMessage({ type: 'error', text: 'キャラクタープロンプトのリセットに失敗しました' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setEditingPrompt(prompt);
+    setIsEditing(false);
+  };
+
+  const handlePromptChange = (value: string) => {
+    setEditingPrompt(value);
+    setIsEditing(true);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-gray-900 border border-gray-700 rounded-lg shadow p-6">
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-2xl font-bold text-blue-400">キャラクター設定</h2>
+          <button
+            onClick={handleReset}
+            className="text-sm text-gray-400 hover:text-gray-200 underline"
+          >
+            デフォルトに戻す
+          </button>
+        </div>
+
+        {message && (
+          <div
+            className={`mb-4 p-4 rounded-lg ${
+              message.type === 'success'
+                ? 'bg-green-50 text-green-800 border border-green-200'
+                : 'bg-red-50 text-red-800 border border-red-200'
+            }`}
+          >
+            {message.text}
+          </div>
+        )}
+
+        <div className="space-y-4">
+          <div>
+            <label
+              htmlFor="global-character-prompt"
+              className="block text-sm font-medium text-gray-300 mb-2"
+            >
+              全プラットフォーム共通キャラクタープロンプト
+            </label>
+            <p className="text-sm text-gray-400 mb-3">
+              このプロンプトは全てのSNSプラットフォームでのコンテンツ生成時に共通して使用されます。あなたのキャラクターやトーン、目的を設定してください。
+            </p>
+            <textarea
+              id="global-character-prompt"
+              value={editingPrompt}
+              onChange={(e) => handlePromptChange(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-600 rounded-lg bg-gray-800 text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
+              rows={6}
+              placeholder="例：あなたは親しみやすく、創造性豊かなコンテンツクリエイターです。読者・視聴者に価値のある情報を分かりやすく、魅力的に伝えることを心がけています。"
+              maxLength={5000}
+            />
+            <div className="flex justify-between mt-2">
+              <p className="text-xs text-gray-500">
+                最大5000文字まで入力できます
+              </p>
+              <p className="text-xs text-gray-500">
+                {editingPrompt.length}/5000
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {isEditing && (
+          <div className="flex justify-end space-x-3 mt-6 pt-6 border-t border-gray-700">
+            <button
+              onClick={handleCancel}
+              disabled={saving}
+              className="px-6 py-2 border border-gray-600 rounded-lg text-gray-300 hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              キャンセル
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving || editingPrompt.length > 5000}
+              className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
+            >
+              {saving ? (
+                <>
+                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
+                  保存中...
+                </>
+              ) : (
+                '保存'
+              )}
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div className="bg-gray-800 border border-gray-600 rounded-lg p-4">
+        <h3 className="font-semibold text-blue-400 mb-2">キャラクタープロンプトとは？</h3>
+        <ul className="text-sm text-gray-300 space-y-1 list-disc list-inside">
+          <li>全てのプラットフォームで共通して使用される基本的なキャラクター設定です</li>
+          <li>あなたの口調、専門分野、目的、価値観などを設定してください</li>
+          <li>各プラットフォーム専用のプロンプトと組み合わせて使用されます</li>
+          <li>一貫性のあるブランディングとコンテンツ作成に役立ちます</li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/settings/character/page.tsx
+++ b/apps/web/src/app/settings/character/page.tsx
@@ -1,0 +1,55 @@
+import { auth } from '../../../../auth';
+import { cookies } from 'next/headers';
+import { CharacterPromptForm } from './CharacterPromptForm';
+import { redirect } from 'next/navigation';
+
+interface UserSettings {
+  globalCharacterPrompt: string;
+}
+
+async function fetchGlobalCharacterPrompt(token: string): Promise<string> {
+  const apiUrl = process.env.INTERNAL_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://api:8787';
+
+  try {
+    const response = await fetch(`${apiUrl}/user-settings/global-character-prompt`, {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      },
+      cache: 'no-store'
+    });
+
+    if (!response.ok) {
+      console.error('Failed to fetch global character prompt:', response.status);
+      return 'あなたは親しみやすく、創造性豊かなコンテンツクリエイターです。読者・視聴者に価値のある情報を分かりやすく、魅力的に伝えることを心がけています。';
+    }
+
+    const data = await response.json();
+    return data.globalCharacterPrompt || 'あなたは親しみやすく、創造性豊かなコンテンツクリエイターです。読者・視聴者に価値のある情報を分かりやすく、魅力的に伝えることを心がけています。';
+  } catch (error) {
+    console.error('Error fetching global character prompt:', error);
+    return 'あなたは親しみやすく、創造性豊かなコンテンツクリエイターです。読者・視聴者に価値のある情報を分かりやすく、魅力的に伝えることを心がけています。';
+  }
+}
+
+export default async function CharacterPromptPage() {
+  // テスト用：認証チェックを一時的に無効化
+  // const session = await auth();
+  // if (!session?.user) {
+  //   redirect('/');
+  // }
+
+  // テスト用ダミートークン
+  const token = 'test-token';
+  const globalCharacterPrompt = await fetchGlobalCharacterPrompt(token);
+
+  return (
+    <div className="min-h-screen bg-black">
+      <div className="container mx-auto px-4 py-8 max-w-4xl">
+        <CharacterPromptForm
+          initialPrompt={globalCharacterPrompt}
+          token={token}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/settings/prompts/PromptForm.tsx
+++ b/apps/web/src/app/settings/prompts/PromptForm.tsx
@@ -20,16 +20,18 @@ const platformLabels: Record<Platform, string> = {
 
 interface PromptFormProps {
   initialPrompts: Prompts;
+  combinedPrompts: Prompts;
   token: string;
 }
 
-export function PromptForm({ initialPrompts, token }: PromptFormProps) {
+export function PromptForm({ initialPrompts, combinedPrompts, token }: PromptFormProps) {
   const router = useRouter();
   const [prompts, setPrompts] = useState<Prompts>(initialPrompts);
   const [editingPrompts, setEditingPrompts] = useState<Prompts>(initialPrompts);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [isEditing, setIsEditing] = useState(false);
+  const [showCombined, setShowCombined] = useState(false);
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8787';
 
@@ -106,15 +108,27 @@ export function PromptForm({ initialPrompts, token }: PromptFormProps) {
 
   return (
     <div className="space-y-6">
-      <div className="bg-white rounded-lg shadow p-6">
+      <div className="bg-gray-900 border border-gray-700 rounded-lg shadow p-6">
         <div className="flex items-center justify-between mb-6">
-          <h2 className="text-2xl font-bold text-gray-900">プロンプト設定</h2>
-          <button
-            onClick={handleReset}
-            className="text-sm text-gray-600 hover:text-gray-800 underline"
-          >
-            デフォルトに戻す
-          </button>
+          <h2 className="text-2xl font-bold text-blue-400">プロンプト設定</h2>
+          <div className="flex items-center gap-4">
+            <button
+              onClick={() => setShowCombined(!showCombined)}
+              className={`text-sm px-3 py-1 rounded-lg transition-colors ${
+                showCombined
+                  ? 'bg-blue-100 text-blue-800'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {showCombined ? '編集モード' : '統合プロンプト表示'}
+            </button>
+            <button
+              onClick={handleReset}
+              className="text-sm text-gray-400 hover:text-gray-200 underline"
+            >
+              デフォルトに戻す
+            </button>
+          </div>
         </div>
 
         {message && (
@@ -131,31 +145,46 @@ export function PromptForm({ initialPrompts, token }: PromptFormProps) {
 
         <div className="space-y-4">
           {(Object.keys(platformLabels) as Platform[]).map((platform) => (
-            <div key={platform} className="border border-gray-200 rounded-lg p-4">
+            <div key={platform} className="border border-gray-600 rounded-lg p-4 bg-gray-800">
               <label
                 htmlFor={`prompt-${platform}`}
-                className="block text-sm font-medium text-gray-700 mb-2"
+                className="block text-sm font-medium text-gray-300 mb-2"
               >
                 {platformLabels[platform]}
+                {showCombined && (
+                  <span className="ml-2 text-xs text-blue-400">(統合プロンプト)</span>
+                )}
               </label>
               <textarea
                 id={`prompt-${platform}`}
-                value={editingPrompts[platform] || ''}
-                onChange={(e) => handlePromptChange(platform, e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
-                rows={3}
-                placeholder={`${platformLabels[platform]}用のプロンプトを入力してください`}
+                value={showCombined ? combinedPrompts[platform] || '' : editingPrompts[platform] || ''}
+                onChange={!showCombined ? (e) => handlePromptChange(platform, e.target.value) : undefined}
+                className={`w-full px-3 py-2 border border-gray-600 rounded-lg bg-gray-700 text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none ${
+                  showCombined ? 'bg-gray-600' : ''
+                }`}
+                rows={showCombined ? 6 : 3}
+                placeholder={
+                  showCombined
+                    ? 'キャラクタープロンプト + プラットフォーム固有プロンプトの統合表示'
+                    : `${platformLabels[platform]}用のプロンプトを入力してください`
+                }
+                readOnly={showCombined}
               />
+              {showCombined && (
+                <p className="text-xs text-gray-400 mt-2">
+                  ※ 実際の生成時に使用される統合プロンプトです（読み取り専用）
+                </p>
+              )}
             </div>
           ))}
         </div>
 
-        {isEditing && (
-          <div className="flex justify-end space-x-3 mt-6 pt-6 border-t border-gray-200">
+        {isEditing && !showCombined && (
+          <div className="flex justify-end space-x-3 mt-6 pt-6 border-t border-gray-700">
             <button
               onClick={handleCancel}
               disabled={saving}
-              className="px-6 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-6 py-2 border border-gray-600 rounded-lg text-gray-300 hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               キャンセル
             </button>
@@ -177,11 +206,12 @@ export function PromptForm({ initialPrompts, token }: PromptFormProps) {
         )}
       </div>
 
-      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-        <h3 className="font-semibold text-blue-900 mb-2">使い方</h3>
-        <ul className="text-sm text-blue-800 space-y-1 list-disc list-inside">
+      <div className="bg-gray-800 border border-gray-600 rounded-lg p-4">
+        <h3 className="font-semibold text-blue-400 mb-2">使い方</h3>
+        <ul className="text-sm text-gray-300 space-y-1 list-disc list-inside">
           <li>各プラットフォーム用のプロンプトをカスタマイズできます</li>
-          <li>プロンプトは自動的にコンテンツ生成時に使用されます</li>
+          <li>「統合プロンプト表示」で実際の生成時に使用される完全なプロンプトを確認できます</li>
+          <li>統合プロンプト = キャラクタープロンプト + プラットフォーム固有プロンプト</li>
           <li>空のプロンプトの場合はデフォルトのプロンプトが使用されます</li>
           <li>「デフォルトに戻す」をクリックすると、全てのプロンプトがリセットされます</li>
         </ul>

--- a/apps/web/src/app/settings/prompts/page.tsx
+++ b/apps/web/src/app/settings/prompts/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from '@/../../auth';
+import { auth } from '../../../../auth';
 import { cookies } from 'next/headers';
 import { PromptForm } from './PromptForm';
 import { redirect } from 'next/navigation';
@@ -7,9 +7,13 @@ interface Prompts {
   [key: string]: string;
 }
 
+interface CombinedPrompts {
+  [key: string]: string;
+}
+
 async function fetchPrompts(token: string): Promise<Prompts> {
   const apiUrl = process.env.INTERNAL_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://api:8787';
-  
+
   try {
     const response = await fetch(`${apiUrl}/prompts`, {
       headers: {
@@ -31,23 +35,51 @@ async function fetchPrompts(token: string): Promise<Prompts> {
   }
 }
 
-export default async function PromptsPage() {
-  const session = await auth();
-  
-  if (!session?.user) {
-    redirect('/');
+async function fetchCombinedPrompts(token: string): Promise<CombinedPrompts> {
+  const apiUrl = process.env.INTERNAL_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://api:8787';
+
+  try {
+    const response = await fetch(`${apiUrl}/prompts/combined`, {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      },
+      cache: 'no-store'
+    });
+
+    if (!response.ok) {
+      console.error('Failed to fetch combined prompts:', response.status);
+      return {};
+    }
+
+    const data = await response.json();
+    return data.prompts || {};
+  } catch (error) {
+    console.error('Error fetching combined prompts:', error);
+    return {};
   }
+}
 
-  // JWTトークンを取得
-  const cookieStore = await cookies();
-  const token = cookieStore.get('authjs.session-token')?.value || 
-                cookieStore.get('__Secure-authjs.session-token')?.value || '';
+export default async function PromptsPage() {
+  // テスト用：認証チェックを一時的に無効化
+  // const session = await auth();
+  // if (!session?.user) {
+  //   redirect('/');
+  // }
 
+  // テスト用ダミートークン
+  const token = 'test-token';
   const prompts = await fetchPrompts(token);
+  const combinedPrompts = await fetchCombinedPrompts(token);
 
   return (
-    <div className="container mx-auto px-4 py-8 max-w-4xl">
-      <PromptForm initialPrompts={prompts} token={token} />
+    <div className="min-h-screen bg-black">
+      <div className="container mx-auto px-4 py-8 max-w-4xl">
+        <PromptForm
+          initialPrompts={prompts}
+          combinedPrompts={combinedPrompts}
+          token={token}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { SignInButton } from "./SignInButton";
 import { SignOutButton } from "./SignOutButton";
 import { HeaderMenuButton } from "./HeaderMenuButton";
+import { PromptSettingsMenu } from "./PromptSettingsMenu";
 
 export async function Header() {
   const session = await auth();
@@ -17,25 +18,30 @@ export async function Header() {
           </h1>
         </div>
 
-        {session?.user ? (
-          <div className="flex items-center gap-3">
-            {session.user.image && (
-              <Image
-                src={session.user.image}
-                alt={session.user.name || "User"}
-                width={32}
-                height={32}
-                className="rounded-full"
-              />
-            )}
-            <span className="text-sm text-gray-700 hidden md:inline">
-              {session.user.name}
-            </span>
-            <SignOutButton />
-          </div>
-        ) : (
-          <SignInButton />
-        )}
+        <div className="flex items-center gap-3">
+          {/* テスト用：認証状態に関係なくプロンプト設定を表示 */}
+          <PromptSettingsMenu />
+
+          {session?.user ? (
+            <>
+              {session.user.image && (
+                <Image
+                  src={session.user.image}
+                  alt={session.user.name || "User"}
+                  width={32}
+                  height={32}
+                  className="rounded-full"
+                />
+              )}
+              <span className="text-sm text-gray-700 hidden md:inline">
+                {session.user.name}
+              </span>
+              <SignOutButton />
+            </>
+          ) : (
+            <SignInButton />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/HistoryPromptModal.tsx
+++ b/apps/web/src/components/HistoryPromptModal.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+interface HistoryPromptModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  threadId: string;
+  platforms: string[];
+  token: string;
+}
+
+interface HistoryPrompt {
+  platform: string;
+  generationPrompt?: string;
+  globalCharacterPrompt?: string;
+  platformPrompt?: string;
+  combinedPrompt?: string;
+}
+
+const platformLabels: Record<string, string> = {
+  twitter: 'X (Twitter)',
+  instagram: 'Instagram',
+  tiktok: 'TikTok',
+  threads: 'Threads',
+  youtube: 'YouTube',
+  wordpress: 'WordPress（ブログ）',
+  blog: 'ブログ'
+};
+
+export function HistoryPromptModal({
+  isOpen,
+  onClose,
+  threadId,
+  platforms,
+  token
+}: HistoryPromptModalProps) {
+  const [prompts, setPrompts] = useState<HistoryPrompt[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copyNotification, setCopyNotification] = useState<string | null>(null);
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8787';
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchHistoryPrompts();
+    }
+  }, [isOpen, threadId]);
+
+  const fetchHistoryPrompts = async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      // 履歴データからプロンプト情報を取得
+      const response = await fetch(`${apiUrl}/history/${threadId}/prompts`, {
+        headers: {
+          'Authorization': `Bearer ${token}`
+        },
+        cache: 'no-store'
+      });
+
+      if (!response.ok) {
+        // APIエンドポイントが存在しない場合は、デフォルトメッセージを表示
+        if (response.status === 404) {
+          setPrompts(platforms.map(platform => ({
+            platform,
+            generationPrompt: '履歴からプロンプト情報を取得できませんでした。この機能は今後のバージョンで利用可能になります。'
+          })));
+        } else {
+          throw new Error('Failed to fetch history prompts');
+        }
+      } else {
+        const data = await response.json();
+        setPrompts(data.prompts || []);
+      }
+    } catch (error) {
+      console.error('Error fetching history prompts:', error);
+      // エラー時はプレースホルダーメッセージを表示
+      setPrompts(platforms.map(platform => ({
+        platform,
+        generationPrompt: '履歴からプロンプト情報を取得できませんでした。'
+      })));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const copyToClipboard = async (text: string, label: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopyNotification(`${label}をコピーしました`);
+      setTimeout(() => setCopyNotification(null), 2000);
+    } catch (error) {
+      console.error('Failed to copy to clipboard:', error);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="flex items-center justify-between p-6 border-b border-gray-200">
+          <h2 className="text-xl font-semibold text-gray-900">
+            使用されたプロンプト
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-6">
+          {loading && (
+            <div className="flex items-center justify-center py-8">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+              <span className="ml-3 text-gray-600">プロンプト情報を取得中...</span>
+            </div>
+          )}
+
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+              <p className="text-red-800">{error}</p>
+            </div>
+          )}
+
+          {!loading && !error && (
+            <div className="space-y-6">
+              {prompts.map((promptData) => {
+                const label = platformLabels[promptData.platform] || promptData.platform;
+
+                return (
+                  <div key={promptData.platform} className="border border-gray-200 rounded-lg p-4">
+                    <h3 className="text-lg font-medium text-gray-900 mb-3">{label}</h3>
+
+                    {promptData.generationPrompt ? (
+                      <div className="space-y-4">
+                        <div>
+                          <div className="flex items-center justify-between mb-2">
+                            <label className="block text-sm font-medium text-gray-700">
+                              生成時に使用されたプロンプト
+                            </label>
+                            <button
+                              onClick={() => copyToClipboard(promptData.generationPrompt!, `${label}のプロンプト`)}
+                              className="text-sm text-blue-600 hover:text-blue-800 flex items-center gap-1"
+                            >
+                              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                              </svg>
+                              コピー
+                            </button>
+                          </div>
+                          <textarea
+                            value={promptData.generationPrompt}
+                            readOnly
+                            className="w-full px-3 py-2 border border-gray-300 rounded-lg bg-gray-50 resize-none focus:outline-none"
+                            rows={6}
+                          />
+                        </div>
+
+                        {promptData.globalCharacterPrompt && (
+                          <div>
+                            <div className="flex items-center justify-between mb-2">
+                              <label className="block text-sm font-medium text-gray-700">
+                                グローバルキャラクタープロンプト
+                              </label>
+                              <button
+                                onClick={() => copyToClipboard(promptData.globalCharacterPrompt!, 'グローバルキャラクタープロンプト')}
+                                className="text-sm text-blue-600 hover:text-blue-800 flex items-center gap-1"
+                              >
+                                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                </svg>
+                                コピー
+                              </button>
+                            </div>
+                            <textarea
+                              value={promptData.globalCharacterPrompt}
+                              readOnly
+                              className="w-full px-3 py-2 border border-gray-300 rounded-lg bg-gray-50 resize-none focus:outline-none"
+                              rows={3}
+                            />
+                          </div>
+                        )}
+
+                        {promptData.platformPrompt && (
+                          <div>
+                            <div className="flex items-center justify-between mb-2">
+                              <label className="block text-sm font-medium text-gray-700">
+                                プラットフォーム固有プロンプト
+                              </label>
+                              <button
+                                onClick={() => copyToClipboard(promptData.platformPrompt!, 'プラットフォーム固有プロンプト')}
+                                className="text-sm text-blue-600 hover:text-blue-800 flex items-center gap-1"
+                              >
+                                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                                </svg>
+                                コピー
+                              </button>
+                            </div>
+                            <textarea
+                              value={promptData.platformPrompt}
+                              readOnly
+                              className="w-full px-3 py-2 border border-gray-300 rounded-lg bg-gray-50 resize-none focus:outline-none"
+                              rows={3}
+                            />
+                          </div>
+                        )}
+                      </div>
+                    ) : (
+                      <p className="text-gray-500 text-sm">
+                        このプラットフォームのプロンプト情報は利用できません。
+                      </p>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="border-t border-gray-200 p-6">
+          <div className="flex justify-between items-center">
+            <div className="text-sm text-gray-500">
+              ※ プロンプト情報は生成時のスナップショットです
+            </div>
+            <button
+              onClick={onClose}
+              className="px-6 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors"
+            >
+              閉じる
+            </button>
+          </div>
+        </div>
+
+        {/* Copy notification */}
+        {copyNotification && (
+          <div className="fixed bottom-4 right-4 bg-green-600 text-white px-4 py-2 rounded-lg shadow-lg z-60">
+            {copyNotification}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/PromptSettingsMenu.tsx
+++ b/apps/web/src/components/PromptSettingsMenu.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+export function PromptSettingsMenu() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors shadow-sm"
+        aria-expanded={isOpen}
+        aria-haspopup="true"
+      >
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+          />
+        </svg>
+        プロンプト設定
+      </button>
+
+      {isOpen && (
+        <>
+          {/* Overlay */}
+          <div
+            className="fixed inset-0 z-10"
+            onClick={() => setIsOpen(false)}
+          />
+
+          {/* Dropdown Menu */}
+          <div className="absolute right-0 z-20 mt-2 w-56 bg-white border border-gray-200 rounded-lg shadow-lg">
+            <div className="py-2">
+              <Link
+                href="/settings/character"
+                className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                onClick={() => setIsOpen(false)}
+              >
+                <svg
+                  className="w-4 h-4 mr-3"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                  />
+                </svg>
+                キャラクター設定
+                <span className="ml-auto text-xs text-gray-500">全体</span>
+              </Link>
+
+              <Link
+                href="/settings/prompts"
+                className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 hover:text-gray-900"
+                onClick={() => setIsOpen(false)}
+              >
+                <svg
+                  className="w-4 h-4 mr-3"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+                  />
+                </svg>
+                プラットフォーム別設定
+                <span className="ml-auto text-xs text-gray-500">個別</span>
+              </Link>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/SourceForm.tsx
+++ b/apps/web/src/components/SourceForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { ChangeEvent, FormEvent } from "react";
+import { ChangeEvent, FormEvent, useState } from "react";
+import { TempPromptModal } from "./TempPromptModal";
 
 interface SourceFormProps {
   sourceType: "text" | "audio" | "video";
@@ -12,6 +13,10 @@ interface SourceFormProps {
   setTargets: (value: string[]) => void;
   isProcessing: boolean;
   handleSubmit: (e: FormEvent) => void;
+  userId?: string;
+  isAuthenticated?: boolean;
+  tempPrompts?: Record<string, string>;
+  onTempPromptsChange?: (prompts: Record<string, string>) => void;
 }
 
 const platformOptions = [
@@ -33,7 +38,29 @@ export const SourceForm = ({
   setTargets,
   isProcessing,
   handleSubmit,
+  userId,
+  isAuthenticated,
+  tempPrompts = {},
+  onTempPromptsChange,
 }: SourceFormProps) => {
+  const [isPromptModalOpen, setIsPromptModalOpen] = useState(false);
+  const [token, setToken] = useState('');
+
+  // トークンを取得（簡易的な実装）
+  const getAuthToken = () => {
+    if (typeof window !== 'undefined') {
+      // クッキーからトークンを取得する簡易実装
+      const cookies = document.cookie.split(';');
+      for (const cookie of cookies) {
+        const [name, value] = cookie.trim().split('=');
+        if (name === 'authjs.session-token' || name === '__Secure-authjs.session-token') {
+          return value;
+        }
+      }
+    }
+    return '';
+  };
+
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     setFile(e.target.files?.[0] || null);
   };
@@ -48,50 +75,50 @@ export const SourceForm = ({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
-      <div className="bg-white rounded-lg shadow p-6">
-        <h2 className="text-xl font-semibold mb-4">1. 入力タイプを選択</h2>
+      <div className="bg-gray-800 border border-gray-700 rounded-lg shadow p-6">
+        <h2 className="text-xl font-semibold mb-4 text-white">1. 入力タイプを選択</h2>
         <div className="flex space-x-4">
-          <label>
+          <label className="text-gray-300">
             <input
               type="radio"
               value="text"
               checked={sourceType === "text"}
               onChange={() => setSourceType("text")}
-              className="mr-2"
+              className="mr-2 accent-blue-500"
             />
             テキスト
           </label>
-          <label>
+          <label className="text-gray-300">
             <input
               type="radio"
               value="audio"
               checked={sourceType === "audio"}
               onChange={() => setSourceType("audio")}
-              className="mr-2"
+              className="mr-2 accent-blue-500"
             />
             音声
           </label>
-          <label>
+          <label className="text-gray-300">
             <input
               type="radio"
               value="video"
               checked={sourceType === "video"}
               onChange={() => setSourceType("video")}
-              className="mr-2"
+              className="mr-2 accent-blue-500"
             />
             動画
           </label>
         </div>
       </div>
 
-      <div className="bg-white rounded-lg shadow p-6">
-        <h2 className="text-xl font-semibold mb-4">2. コンテンツ入力</h2>
+      <div className="bg-gray-800 border border-gray-700 rounded-lg shadow p-6">
+        <h2 className="text-xl font-semibold mb-4 text-white">2. コンテンツ入力</h2>
         {sourceType === "text" ? (
           <textarea
             value={content}
             onChange={(e) => setContent(e.target.value)}
             placeholder="コンテンツのテキストを入力してください..."
-            className="w-full h-40 p-3 border rounded-md"
+            className="w-full h-40 p-3 border border-gray-600 rounded-md bg-gray-700 text-white placeholder-gray-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
             required
           />
         ) : (
@@ -99,22 +126,55 @@ export const SourceForm = ({
             type="file"
             accept={sourceType === "audio" ? "audio/*" : "video/*"}
             onChange={handleFileChange}
-            className="w-full p-3 border rounded-md"
+            className="w-full p-3 border border-gray-600 rounded-md bg-gray-700 text-white file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-blue-600 file:text-white hover:file:bg-blue-700"
             required
           />
         )}
       </div>
 
-      <div className="bg-white rounded-lg shadow p-6">
-        <h2 className="text-xl font-semibold mb-4">3. 投稿先を選択</h2>
+      <div className="bg-gray-800 border border-gray-700 rounded-lg shadow p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-xl font-semibold text-white">3. 投稿先を選択</h2>
+          {targets.length > 0 && (
+            <button
+              type="button"
+              onClick={() => {
+                setToken(getAuthToken());
+                setIsPromptModalOpen(true);
+              }}
+              className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-lg transition-colors shadow-sm"
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+              </svg>
+              一時プロンプト設定
+            </button>
+          )}
+        </div>
         <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
           {platformOptions.map((platform) => (
             <label
               key={platform.id}
               className={`p-4 border-2 rounded-lg cursor-pointer transition-colors ${
                 targets.includes(platform.id)
-                  ? "border-blue-500 bg-blue-50"
-                  : "border-gray-200"
+                  ? "border-blue-500 bg-blue-900 bg-opacity-50"
+                  : "border-gray-600 bg-gray-750"
               }`}
             >
               <input
@@ -123,21 +183,47 @@ export const SourceForm = ({
                 onChange={() => handleTargetToggle(platform.id)}
                 className="sr-only"
               />
-              <span className="font-medium">{platform.name}</span>
+              <span className="font-medium text-white">{platform.name}</span>
+              {tempPrompts[platform.id] && (
+                <div className="mt-2">
+                  <span className="inline-block px-2 py-1 text-xs bg-yellow-600 text-yellow-100 rounded">
+                    カスタムプロンプト設定済み
+                  </span>
+                </div>
+              )}
             </label>
           ))}
         </div>
+        {targets.length === 0 && (
+          <p className="text-sm text-gray-400 mt-4">
+            投稿先を選択すると、一時プロンプト設定ボタンが表示されます
+          </p>
+        )}
       </div>
 
       <div className="flex justify-center">
         <button
           type="submit"
           disabled={isProcessing}
-          className="px-8 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 disabled:bg-gray-400 cursor-pointer"
+          className="px-8 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 disabled:bg-gray-500 cursor-pointer transition-colors"
         >
           {isProcessing ? "処理中..." : "コンテンツを生成"}
         </button>
       </div>
+
+      {/* 一時プロンプト設定モーダル */}
+      <TempPromptModal
+        isOpen={isPromptModalOpen}
+        onClose={() => setIsPromptModalOpen(false)}
+        selectedPlatforms={targets}
+        onSavePrompts={(prompts) => {
+          if (onTempPromptsChange) {
+            onTempPromptsChange(prompts);
+          }
+        }}
+        initialPrompts={tempPrompts}
+        token={token}
+      />
     </form>
   );
 };

--- a/apps/web/src/components/TempPromptModal.tsx
+++ b/apps/web/src/components/TempPromptModal.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+
+// type Platform = 'twitter' | 'instagram' | 'tiktok' | 'threads' | 'youtube' | 'blog';
+
+interface TempPromptModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  selectedPlatforms: string[];
+  onSavePrompts: (prompts: Record<string, string>) => void;
+  initialPrompts: Record<string, string>;
+  token: string;
+}
+
+const platformLabels: Record<string, string> = {
+  twitter: 'X (Twitter)',
+  instagram: 'Instagram',
+  tiktok: 'TikTok',
+  threads: 'Threads',
+  youtube: 'YouTube',
+  wordpress: 'WordPress（ブログ）'
+};
+
+const platformMapping: Record<string, string> = {
+  wordpress: 'blog'
+};
+
+export function TempPromptModal({
+  isOpen,
+  onClose,
+  selectedPlatforms,
+  onSavePrompts,
+  initialPrompts,
+  token
+}: TempPromptModalProps) {
+  const [tempPrompts, setTempPrompts] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+  const [combinedPrompts, setCombinedPrompts] = useState<Record<string, string>>({});
+  const [showCombined, setShowCombined] = useState(false);
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8787';
+
+  // プラットフォームIDを正規化（wordpress -> blog）
+  const normalizedPlatforms = selectedPlatforms.map(p => platformMapping[p] || p);
+
+  const fetchCombinedPrompts = useCallback(async () => {
+    try {
+      const combined: Record<string, string> = {};
+      for (const platform of normalizedPlatforms) {
+        const response = await fetch(`${apiUrl}/prompts/combined/${platform}`, {
+          headers: {
+            'Authorization': `Bearer ${token}`
+          },
+          cache: 'no-store'
+        });
+
+        if (response.ok) {
+          const data = await response.json();
+          combined[platform] = data.combinedPrompt || '';
+        }
+      }
+      setCombinedPrompts(combined);
+    } catch (error) {
+      console.error('Error fetching combined prompts:', error);
+    }
+  }, [normalizedPlatforms, apiUrl, token]);
+
+  useEffect(() => {
+    if (isOpen) {
+      // 初期プロンプトを設定
+      const initial: Record<string, string> = {};
+      normalizedPlatforms.forEach(platform => {
+        initial[platform] = initialPrompts[platform] || '';
+      });
+      setTempPrompts(initial);
+
+      // 統合プロンプトを取得
+      fetchCombinedPrompts();
+    }
+  }, [isOpen, selectedPlatforms, initialPrompts, normalizedPlatforms, fetchCombinedPrompts]);
+
+  const handlePromptChange = (platform: string, value: string) => {
+    setTempPrompts(prev => ({ ...prev, [platform]: value }));
+  };
+
+  const handleSaveToDatabase = async () => {
+    setLoading(true);
+    try {
+      // データベースに保存
+      const response = await fetch(`${apiUrl}/prompts/batch`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ prompts: tempPrompts })
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to save prompts to database');
+      }
+
+      // 一時プロンプトとしても設定
+      onSavePrompts(tempPrompts);
+      onClose();
+    } catch (error) {
+      console.error('Error saving prompts to database:', error);
+      alert('プロンプトの保存に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleUseForGeneration = () => {
+    // 今回の生成にのみ使用
+    onSavePrompts(tempPrompts);
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col">
+        <div className="flex items-center justify-between p-6 border-b border-gray-200">
+          <h2 className="text-xl font-semibold text-gray-900">
+            一時プロンプト設定
+          </h2>
+          <div className="flex items-center gap-4">
+            <button
+              onClick={() => setShowCombined(!showCombined)}
+              className={`text-sm px-3 py-1 rounded-lg transition-colors ${
+                showCombined
+                  ? 'bg-blue-100 text-blue-800'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {showCombined ? '編集モード' : '統合プロンプト表示'}
+            </button>
+            <button
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600 transition-colors"
+            >
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-6">
+          <div className="space-y-4">
+            {normalizedPlatforms.map((platform) => {
+              const displayPlatform = Object.keys(platformMapping).find(key => platformMapping[key] === platform) || platform;
+              const label = platformLabels[displayPlatform] || displayPlatform;
+
+              return (
+                <div key={platform} className="border border-gray-200 rounded-lg p-4">
+                  <label
+                    htmlFor={`temp-prompt-${platform}`}
+                    className="block text-sm font-medium text-gray-700 mb-2"
+                  >
+                    {label}
+                    {showCombined && (
+                      <span className="ml-2 text-xs text-blue-600">(統合プロンプト)</span>
+                    )}
+                  </label>
+                  <textarea
+                    id={`temp-prompt-${platform}`}
+                    value={showCombined ? combinedPrompts[platform] || '' : tempPrompts[platform] || ''}
+                    onChange={!showCombined ? (e) => handlePromptChange(platform, e.target.value) : undefined}
+                    className={`w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none ${
+                      showCombined ? 'bg-gray-50' : ''
+                    }`}
+                    rows={showCombined ? 6 : 4}
+                    placeholder={
+                      showCombined
+                        ? 'キャラクタープロンプト + プラットフォーム固有プロンプトの統合表示'
+                        : `${label}用のプロンプトを入力してください（空の場合はデフォルトプロンプトが使用されます）`
+                    }
+                    readOnly={showCombined}
+                  />
+                  {showCombined && (
+                    <p className="text-xs text-gray-500 mt-2">
+                      ※ 実際の生成時に使用される統合プロンプトです（読み取り専用）
+                    </p>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {!showCombined && (
+          <div className="border-t border-gray-200 p-6">
+            <div className="flex justify-end space-x-3">
+              <button
+                onClick={onClose}
+                className="px-6 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 transition-colors"
+              >
+                キャンセル
+              </button>
+              <button
+                onClick={handleUseForGeneration}
+                className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              >
+                今回の生成に使用
+              </button>
+              <button
+                onClick={handleSaveToDatabase}
+                disabled={loading}
+                className="px-6 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                {loading ? (
+                  <>
+                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2 inline-block"></div>
+                    保存中...
+                  </>
+                ) : (
+                  '設定を保存して使用'
+                )}
+              </button>
+            </div>
+            <p className="text-xs text-gray-500 mt-3">
+              ※「今回の生成に使用」は一時的に使用し、「設定を保存して使用」はデータベースに保存して今後も使用します
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ThreadView.tsx
+++ b/apps/web/src/components/ThreadView.tsx
@@ -5,6 +5,7 @@ import { getApiUrl } from '../lib/config';
 import { PlatformContent as CorePlatformContent } from '@one-to-multi-agent/core';
 import { PlatformCard } from './PlatformCard';
 import { PlatformResult } from '../hooks/useContentGenerator';
+import { HistoryPromptModal } from './HistoryPromptModal';
 
 interface AudioPreview {
   duration: number;
@@ -53,6 +54,8 @@ export function ThreadView({ threadId, userId }: ThreadViewProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [editableContent, setEditableContent] = useState<Record<string, Partial<CorePlatformContent>>>({});
+  const [isPromptModalOpen, setIsPromptModalOpen] = useState(false);
+  const [token, setToken] = useState('');
 
   const fetchThread = async () => {
     setLoading(true);
@@ -129,6 +132,21 @@ export function ThreadView({ threadId, userId }: ThreadViewProps) {
     return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
   };
 
+  // トークンを取得（簡易的な実装）
+  const getAuthToken = () => {
+    if (typeof window !== 'undefined') {
+      // クッキーからトークンを取得する簡易実装
+      const cookies = document.cookie.split(';');
+      for (const cookie of cookies) {
+        const [name, value] = cookie.trim().split('=');
+        if (name === 'authjs.session-token' || name === '__Secure-authjs.session-token') {
+          return value;
+        }
+      }
+    }
+    return '';
+  };
+
   const getSourceTypeDisplay = (sourceType: string) => {
     switch (sourceType) {
       case 'text': return 'テキスト';
@@ -185,10 +203,10 @@ export function ThreadView({ threadId, userId }: ThreadViewProps) {
 
   if (loading) {
     return (
-      <div className="flex-1 flex items-center justify-center">
+      <div className="flex-1 flex items-center justify-center bg-gray-900">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div>
-          <p className="mt-2 text-gray-600">読み込み中...</p>
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-400 mx-auto"></div>
+          <p className="mt-2 text-gray-300">読み込み中...</p>
         </div>
       </div>
     );
@@ -196,9 +214,9 @@ export function ThreadView({ threadId, userId }: ThreadViewProps) {
 
   if (error) {
     return (
-      <div className="flex-1 flex items-center justify-center">
+      <div className="flex-1 flex items-center justify-center bg-gray-900">
         <div className="text-center">
-          <p className="text-red-600">エラー: {error}</p>
+          <p className="text-red-400">エラー: {error}</p>
           <button
             onClick={fetchThread}
             className="mt-2 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
@@ -212,28 +230,28 @@ export function ThreadView({ threadId, userId }: ThreadViewProps) {
 
   if (!thread) {
     return (
-      <div className="flex-1 flex items-center justify-center">
-        <p className="text-gray-600">スレッドが見つかりません</p>
+      <div className="flex-1 flex items-center justify-center bg-gray-900">
+        <p className="text-gray-300">スレッドが見つかりません</p>
       </div>
     );
   }
 
   return (
-    <div className="flex-1 overflow-y-auto p-4 md:p-6">
+    <div className="flex-1 overflow-y-auto p-4 md:p-6 bg-gray-900">
       <div className="max-w-4xl mx-auto">
         {/* Thread Header */}
         <div className="mb-4 md:mb-6">
           <div className="flex items-center space-x-2 md:space-x-3 mb-2 flex-wrap">
-            <span className="px-2 md:px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-xs md:text-sm">
+            <span className="px-2 md:px-3 py-1 bg-blue-900 text-blue-300 rounded-full text-xs md:text-sm">
               {getSourceTypeDisplay(thread.sourceType)}
             </span>
-            <span className="text-xs md:text-sm text-gray-500">
+            <span className="text-xs md:text-sm text-gray-400">
               {formatDate(thread.createdAt)}
             </span>
           </div>
           
           {thread.originalFileName && (
-            <div className="flex items-center space-x-2 text-xs md:text-sm text-gray-600 mb-2 flex-wrap">
+            <div className="flex items-center space-x-2 text-xs md:text-sm text-gray-400 mb-2 flex-wrap">
               <span>📎 {thread.originalFileName}</span>
               {thread.duration && (
                 <span>({formatDuration(thread.duration)})</span>
@@ -247,8 +265,8 @@ export function ThreadView({ threadId, userId }: ThreadViewProps) {
 
         {/* Preview Data */}
         {(thread.sourceType === 'video' || thread.sourceType === 'audio' || thread.previewData) && (
-          <div className="mb-6 p-4 bg-gray-50 rounded-lg">
-            <h3 className="font-medium text-gray-800 mb-3">プレビュー</h3>
+          <div className="mb-6 p-4 bg-gray-800 border border-gray-700 rounded-lg">
+            <h3 className="font-medium text-white mb-3">プレビュー</h3>
             
             {thread.sourceType === 'video' && (
               <div className="mb-3">
@@ -263,17 +281,17 @@ export function ThreadView({ threadId, userId }: ThreadViewProps) {
                   お使いのブラウザは動画再生に対応していません。
                 </video>
                 {thread.previewData && 'width' in thread.previewData && 'height' in thread.previewData && (
-                  <div className="mt-2 text-xs text-gray-500">
+                  <div className="mt-2 text-xs text-gray-400">
                     解像度: {thread.previewData.width} × {thread.previewData.height}
                   </div>
                 )}
               </div>
             )}
-            
+
             {thread.sourceType === 'audio' && (
               <div className="mb-3">
-                <audio 
-                  controls 
+                <audio
+                  controls
                   className="w-full max-w-md"
                   src={`${getApiUrl()}/audio/${thread.id}`}
                   preload="metadata"
@@ -281,16 +299,16 @@ export function ThreadView({ threadId, userId }: ThreadViewProps) {
                   お使いのブラウザは音声再生に対応していません。
                 </audio>
                 {thread.previewData && 'duration' in thread.previewData && (
-                  <div className="mt-2 text-xs text-gray-500">
+                  <div className="mt-2 text-xs text-gray-400">
                     長さ: {formatDuration(thread.previewData.duration)}
                   </div>
                 )}
               </div>
             )}
-            
+
             {/* Preview Data that's not audio/video (e.g., waveform visualization for old records) */}
             {thread.previewData && thread.sourceType !== 'audio' && thread.sourceType !== 'video' && (
-              <div className="text-sm text-gray-600">
+              <div className="text-sm text-gray-400">
                 Preview data available
               </div>
             )}
@@ -300,11 +318,11 @@ export function ThreadView({ threadId, userId }: ThreadViewProps) {
         {/* Source Content Display - Only for text input */}
         {thread.sourceType === 'text' && thread.sourceText && (
           <div className="mb-6 md:mb-8">
-            <h3 className="text-lg md:text-xl font-semibold text-gray-800 mb-3">
+            <h3 className="text-lg md:text-xl font-semibold text-white mb-3">
               入力テキスト
             </h3>
-            <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
-              <p className="text-gray-800 whitespace-pre-wrap text-sm md:text-base leading-relaxed">
+            <div className="bg-gray-800 border border-gray-700 rounded-lg p-4">
+              <p className="text-gray-300 whitespace-pre-wrap text-sm md:text-base leading-relaxed">
                 {thread.sourceText}
               </p>
             </div>
@@ -313,17 +331,54 @@ export function ThreadView({ threadId, userId }: ThreadViewProps) {
 
         {/* Generated Content */}
         <div className="mt-6 md:mt-8 space-y-4 md:space-y-6">
-          <h2 className="text-xl md:text-2xl font-bold text-gray-900">生成結果</h2>
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl md:text-2xl font-bold text-white">生成結果</h2>
+            {userId && (
+              <button
+                onClick={() => {
+                  setToken(getAuthToken());
+                  setIsPromptModalOpen(true);
+                }}
+                className="flex items-center gap-2 px-3 py-2 text-sm bg-blue-900 text-blue-300 rounded-lg hover:bg-blue-800 transition-colors"
+              >
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                  />
+                </svg>
+                使用したプロンプトを表示
+              </button>
+            )}
+          </div>
           {getPlatformResults().map((result, i) => (
-            <PlatformCard 
-              key={i} 
-              result={result} 
-              editableContent={editableContent[result.platform]} 
+            <PlatformCard
+              key={i}
+              result={result}
+              editableContent={editableContent[result.platform]}
               updateEditableContent={updateEditableContent}
               handlePublish={handlePublish}
             />
           ))}
         </div>
+
+        {/* 履歴プロンプト表示モーダル */}
+        {userId && (
+          <HistoryPromptModal
+            isOpen={isPromptModalOpen}
+            onClose={() => setIsPromptModalOpen(false)}
+            threadId={threadId}
+            platforms={thread.generatedContent.map(content => content.platform)}
+            token={token}
+          />
+        )}
       </div>
     </div>
   );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: one_to_multi_agent
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./infra/sql:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
  ## Summary
  - 統合プロンプトシステムの実装（グローバルキャラクター + プラットフォーム固有）
  - 一時プロンプト設定機能の追加
  - 履歴でのプロンプト表示機能
  - メイン画面のダークテーマ対応

  ## 主な変更内容

  ### API側
  - `/prompts/combined` エンドポイント追加（統合プロンプト取得）
  - ユーザー設定サービス追加（グローバルキャラクタープロンプト）
  - プロンプトサービスの拡張（統合プロンプト機能）

  ### フロントエンド側
  - ダークテーマ対応（HomeContent, SourceForm, ThreadView）
  - プロンプト設定メニューをヘッダーに追加
  - 一時プロンプト設定モーダル
  - 履歴プロンプト表示モーダル
  - 統合プロンプト表示機能

  ### UI/UX改善
  - レスポンシブデザインの改善
  - カラーテーマの統一（ダークモード）
  - ユーザビリティの向上
